### PR TITLE
Fix: Use Jackson Datatype JDK8 so we can parse optional platforms

### DIFF
--- a/streamlabs4j/build.gradle.kts
+++ b/streamlabs4j/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 	// Jackson (JSON)
 	api(group = "com.fasterxml.jackson.core", name = "jackson-databind")
 	api(group = "com.fasterxml.jackson.core", name = "jackson-annotations")
+	api(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310")
 	api(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jdk8")
 }
 

--- a/streamlabs4j/build.gradle.kts
+++ b/streamlabs4j/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 	// Jackson (JSON)
 	api(group = "com.fasterxml.jackson.core", name = "jackson-databind")
 	api(group = "com.fasterxml.jackson.core", name = "jackson-annotations")
-	api(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310")
+	api(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jdk8")
 }
 
 publishing.publications.withType<MavenPublication> {

--- a/streamlabs4j/src/main/java/com/github/twitch4j/streamlabs4j/api/annotation/Unofficial.java
+++ b/streamlabs4j/src/main/java/com/github/twitch4j/streamlabs4j/api/annotation/Unofficial.java
@@ -1,0 +1,16 @@
+package com.github.twitch4j.streamlabs4j.api.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotates a method or features that uses unofficial api endpoints, those can break at any point in time. Use at your own risk.
+ * <p>
+ * All aspects of this functionality including query parameters and response structure are subject to change without notice.
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+public @interface Unofficial {
+
+}

--- a/streamlabs4j/src/main/java/com/github/twitch4j/streamlabs4j/api/domain/StreamlabsUser.java
+++ b/streamlabs4j/src/main/java/com/github/twitch4j/streamlabs4j/api/domain/StreamlabsUser.java
@@ -67,6 +67,8 @@ public class StreamlabsUser {
 
         /**
          * Primary platform selected by the user
+         *
+         * @apiNote Unofficial field as the official documentation does not reference it.
          */
         private String primary;
 
@@ -156,7 +158,7 @@ public class StreamlabsUser {
         /**
          * Id of the user
          */
-        private String id;
+        private Long id;
 
         /**
          * Name displayed on Facebook's website

--- a/streamlabs4j/src/main/java/com/github/twitch4j/streamlabs4j/api/domain/StreamlabsUser.java
+++ b/streamlabs4j/src/main/java/com/github/twitch4j/streamlabs4j/api/domain/StreamlabsUser.java
@@ -3,6 +3,7 @@ package com.github.twitch4j.streamlabs4j.api.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.github.twitch4j.streamlabs4j.api.annotation.Unofficial;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -67,9 +68,8 @@ public class StreamlabsUser {
 
         /**
          * Primary platform selected by the user
-         *
-         * @apiNote Unofficial field as the official documentation does not reference it.
          */
+        @Unofficial
         private String primary;
 
     }

--- a/streamlabs4j/src/main/java/com/github/twitch4j/streamlabs4j/api/domain/StreamlabsUser.java
+++ b/streamlabs4j/src/main/java/com/github/twitch4j/streamlabs4j/api/domain/StreamlabsUser.java
@@ -65,6 +65,11 @@ public class StreamlabsUser {
          */
         private String displayName;
 
+        /**
+         * Primary platform selected by the user
+         */
+        private String primary;
+
     }
 
     /**
@@ -151,7 +156,7 @@ public class StreamlabsUser {
         /**
          * Id of the user
          */
-        private Long id;
+        private String id;
 
         /**
          * Name displayed on Facebook's website


### PR DESCRIPTION
<!--
	Thanks to using Twitch4J
 	Before you submit pull request read Contributing guidelines.
 	We do not anwser the questions. If you have ask, go to https://discord.gg/FQ5vgW3
 	Issue is not a place for questions and spam.
-->
### Prerequisites
* [x] I have read and understood the [contribution guidelines](https://github.com/twitch4j/twitch4j/blob/master/.github/CONTRIBUTING.md) and I accept them.
* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Issues Fixed 
* Issue #3.

### Changes Proposed
* Swapped Jackson Datatype JSR310 for JDK8.
* Updated Facebook `id` field to use string, as detailed by [Streamlabs' user endpoint](https://dev.streamlabs.com/reference#user).
* Added `primary` field to Streamlabs user.

